### PR TITLE
Add ssh analyzer 

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 analyze
 tests
 .mypy.ini
+configs/work/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ three steps: test generation in C, test profiling using a profiler (perf, gem5 s
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.10+
 - gem5
 
 ## Installation

--- a/configs/ssh.json
+++ b/configs/ssh.json
@@ -1,0 +1,12 @@
+{
+  "profiler": "ssh",
+  "out_dir": "analyze",
+
+  "host": "127.0.0.1",
+  "username": "root",
+  "path_to_key": "/path/to/your/priv/key",
+  "password": "not_recommended",
+
+  "timeout": 3,
+  "max_test_launches": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib==3.8.2
 numpy==1.26.3
 packaging==23.2
 pandas==2.2.0
+paramiko==3.4.0
 Pillow==10.2.0
 pyparsing==3.1.1
 PyQt5==5.15.10

--- a/src/analyzers/backGroundBuildAnalyzer.py
+++ b/src/analyzers/backGroundBuildAnalyzer.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from argparse import Namespace
+
+import logging
+import shutil
+from pathlib import Path
+from tempfile import mkdtemp
+from typing import Dict
+from src.protocols.queueCollector import QueueCollector
+from src.protocols.patcher import Patcher
+
+from src.helpers.backGroundBuilder import BGBuilder
+
+
+class BGBuildAnalyzer:
+    def __init__(self, patcher: Patcher, builder: BGBuilder, collector: QueueCollector, settings: Namespace):
+        self.settings = settings
+        self.patcher = patcher
+        self.collector = collector
+        self.builder = builder
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(self.settings.log_level)
+
+        self.temp_dir: Path = Path(mkdtemp())
+
+    def __del__(self):
+        shutil.rmtree(self.temp_dir)
+
+    def analyze(self, test_dir: Path) -> Dict[str, Dict]:
+        src_dir = self.temp_dir.joinpath("src/")
+        build_dir = self.temp_dir.joinpath("bins/")
+
+        # TODO: may be need to make and background patcher
+        self.patcher.patch(test_dir, src_dir)
+        out_chan = self.builder.build_dir(src_dir, build_dir)
+        res = self.collector.collect(out_chan)
+        return res

--- a/src/analyzers/baseAnalyzer.py
+++ b/src/analyzers/baseAnalyzer.py
@@ -36,6 +36,6 @@ class BaseAnalyzer:
         build_dir = self.temp_dir.joinpath("bins/")
 
         self.patcher.patch(test_dir, src_dir)
-        self.builder.build(src_dir, build_dir)
+        self.builder.build_dir(src_dir, build_dir)
         res = self.collector.collect(build_dir)
         return res

--- a/src/analyzers/collectors/perfCollector.py
+++ b/src/analyzers/collectors/perfCollector.py
@@ -51,7 +51,11 @@ class PerfCollector:
                 "[?]: Maybe perf don't have enough capabilities or your CPU don't have special debug counters\n",
                 file=sys.stderr,
             )
-        return (proc.stdout, is_full)
+
+        res = bytes()
+        if proc.stdout is not None:
+            res = proc.stdout.read()
+        return (res, is_full)
 
     def get_stat(self, binary: Path, number_executes: int, cpu_core: int = 0) -> List[TestRes]:
         stats: List[TestRes] = []

--- a/src/analyzers/collectors/perfCollector.py
+++ b/src/analyzers/collectors/perfCollector.py
@@ -37,6 +37,8 @@ class PerfCollector:
                 pass
             if proc.returncode is not int:  # some bug: if send signal to proc, it ret code will be one
                 proc.returncode = 0
+            elif proc.returncode == 2:  # if it will be work corectly ret with signint should be 2
+                proc.returncode = 0
 
         if proc.stderr is not None:
             test_errors = proc.stderr.read().decode()

--- a/src/analyzers/collectors/perfCollector.py
+++ b/src/analyzers/collectors/perfCollector.py
@@ -35,7 +35,7 @@ class PerfCollector:
             is_full = False
             if proc.poll() is None:
                 pass
-            if proc.returncode is not int:  # some bug: if send signal to proc, it ret code will be one
+            if proc.returncode is not int:  # some bug: if send signal to proc, its ret code will be one
                 proc.returncode = 0
             elif proc.returncode == 2:  # if it will be work corectly ret with signint should be 2
                 proc.returncode = 0

--- a/src/analyzers/collectors/perfParser.py
+++ b/src/analyzers/collectors/perfParser.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple, TypeAlias
 
 from src.protocols.collector import DictSI
 
-TestRes: TypeAlias = Tuple[bytes | None, bool]
+TestRes: TypeAlias = Tuple[bytes, bool]
 
 
 class PerfData:
@@ -66,11 +66,9 @@ class PerfParser:
         return data_dict
 
     @staticmethod
-    def test_res_to_data(out_tup: TestRes) -> PerfData:
-        stream, is_full = out_tup
-        dic: Dict[str, str] = {}
-        if stream is not None:
-            dic = PerfParser.output_to_dict(stream.decode())
+    def test_res_to_data(res: TestRes) -> PerfData:
+        res_bytes, is_full = res
+        dic: Dict[str, str] = PerfParser.output_to_dict(res_bytes.decode())
         return PerfData(dic, is_full)
 
     @staticmethod

--- a/src/analyzers/collectors/perfParser.py
+++ b/src/analyzers/collectors/perfParser.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import sys
-from typing import IO, Any, Dict, List, Tuple, TypeAlias
+from typing import Any, Dict, List, Tuple, TypeAlias
 
 from src.protocols.collector import DictSI
 
-TestRes: TypeAlias = Tuple[IO[bytes] | None, bool]
+TestRes: TypeAlias = Tuple[bytes | None, bool]
 
 
 class PerfData:
@@ -70,7 +70,7 @@ class PerfParser:
         stream, is_full = out_tup
         dic: Dict[str, str] = {}
         if stream is not None:
-            dic = PerfParser.output_to_dict(stream.read().decode())
+            dic = PerfParser.output_to_dict(stream.decode())
         return PerfData(dic, is_full)
 
     @staticmethod

--- a/src/analyzers/collectors/sshCollector.py
+++ b/src/analyzers/collectors/sshCollector.py
@@ -24,13 +24,26 @@ class SshCollector:
         self.is_tmp_created = False
 
         self.host = settings.__dict__.get("host", "127.0.0.1")
-        user = settings.__dict__.get("username", "root")
-        path_to_key = settings.__dict__.get("path_to_key", "~/.ssh/id_rsa")
-        password = settings.__dict__.get("password", "toor")
+        self.user = settings.__dict__.get("username", "root")
+        self.path_to_key = settings.__dict__.get("path_to_key", "~/.ssh/id_rsa")
+        self.password = settings.__dict__.get("password", "toor")
 
+        self.open()
+
+        if bin_dir is None:
+            bin_dir = self.mkdtemp()
+            self.is_tmp_created = True
+        self.bin_dir = bin_dir
+
+    # TODO: understand why it isn't called. Apparently the link to "parrent" analyzer is saved somethere
+    def __del__(self):
+        self.delete_tmp_dir()
+        self.close()
+
+    def open(self):
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(hostname=self.host, username=user, key_filename=path_to_key, password=password)
+        client.connect(hostname=self.host, username=self.user, key_filename=self.path_to_key, password=self.password)
 
         transport = client.get_transport()
         if transport is None:
@@ -43,16 +56,6 @@ class SshCollector:
         self.transport = transport
         self.sftp = sftp
         self.client = client
-
-        if bin_dir is None:
-            bin_dir = self.mkdtemp()
-            self.is_tmp_created = True
-        self.bin_dir = bin_dir
-
-    # TODO: understand why it isn't called. Apparently the link to "parrent" analyzer is saved somethere
-    def __del__(self):
-        self.delete_tmp_dir()
-        self.close()
 
     def delete_tmp_dir(self):
         try:

--- a/src/analyzers/collectors/sshCollector.py
+++ b/src/analyzers/collectors/sshCollector.py
@@ -80,7 +80,9 @@ class SshCollector:
 
     def execute_test(self, execute_line: List[str], timeout: float) -> TestRes:
         execute_str = " ".join(execute_line)
-        chan = self.execute_command(f"timeout -s SIGINT {timeout}s {execute_str}")
+
+        # TODO: sometime timeout don't work and programm hangs
+        chan = self.execute_command(f"timeout --preserve-status -s SIGINT {timeout}s {execute_str}")
 
         is_full = True
         ret_code = chan.recv_exit_status()

--- a/src/analyzers/collectors/sshCollector.py
+++ b/src/analyzers/collectors/sshCollector.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+from argparse import Namespace
+from queue import Queue
+import logging
+import random
+import stat
+from pathlib import Path
+import sys
+import time
+from typing import Dict, List
+
+import paramiko
+
+from src.analyzers.collectors.perfParser import PerfParser, TestRes
+from src.helpers.backGroundBuilder import CSignal
+
+
+class SshCollector:
+    def __init__(self, settings: Namespace, bin_dir: Path | None = None):
+        self.settings = settings
+        self.max_test_launches = settings.__dict__.get("max_test_launches", -1)
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(self.settings.log_level)
+        self.is_tmp_created = False
+
+        host = settings.__dict__.get("host", "127.0.0.1")
+        user = settings.__dict__.get("username", "root")
+        path_to_key = settings.__dict__.get("path_to_key", "~/.ssh/id_rsa")
+        password = settings.__dict__.get("password", "toor")
+
+        self.sftp: paramiko.SFTPClient
+
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.connect(hostname=host, username=user, key_filename=path_to_key, password=password)
+
+        transport = client.get_transport()
+        if transport is None:
+            raise Exception("Can't get transport for ssh")
+
+        sftp = paramiko.SFTPClient.from_transport(transport)
+        if sftp is None:
+            raise Exception("Can't open sftp session")
+
+        self.transport = transport
+        self.sftp = sftp
+        self.client = client
+
+        if bin_dir is None:
+            bin_dir = self.mkdtemp()
+            self.is_tmp_created = True
+        self.bin_dir = bin_dir
+
+    # TODO: understand why it isn't called
+    def __del__(self):
+        if self.is_tmp_created:
+            c = self.execute_command(f"rm -r {self.bin_dir}")
+            c.recv_exit_status()
+
+        # TODO: find how to find out if it is defined or not, may be try catch
+        if self.sftp is not None:
+            self.sftp.close()
+
+        if self.client is not None:
+            self.client.close()
+
+    def execute_command(self, comm: str) -> paramiko.Channel:
+        chan = self.transport.open_session()
+        chan.exec_command(comm)
+        return chan
+
+    def mkdtemp(self) -> Path:
+        dir = f"/tmp/chapy-{random.getrandbits(16)}"
+        self.sftp.mkdir(dir)
+        return Path(dir)
+
+    def tab_lines(self, lines: str):
+        return "\t" + lines.replace("\n", "\n\t")[:-1]
+
+    def execute_test(self, execute_line: List[str], timeout: float) -> TestRes:
+        execute_str = " ".join(execute_line)
+        chan = self.execute_command(f"timeout -s SIGINT {timeout}s {execute_str}")
+
+        is_full = True
+        ret_code = chan.recv_exit_status()
+        if ret_code == 2:
+            is_full = False
+            ret_code = 0
+
+        com_stderr = chan.makefile_stderr()
+        test_errors = com_stderr.read().decode()
+        if len(test_errors) > 0:
+            print(f"[-]: Some error occurred during launching '{execute_str}':", file=sys.stderr)
+            print(self.tab_lines(test_errors), file=sys.stderr, end="")
+        if ret_code != 0:
+            print(
+                "[?]: Maybe perf don't have enough capabilities or your CPU don't have special debug counters\n",
+                file=sys.stderr,
+            )
+        return (chan.recv(1024), is_full)
+
+    def get_stat(self, binary: Path, number_executes: int, cpu_core: int = 0) -> List[TestRes]:
+        stats: List[TestRes] = []
+        execute_line = list(map(str, [binary, cpu_core]))
+        execute_string = " ".join(map(str, execute_line))
+        self.logger.info(f"[sshProfiler]: Executing: {execute_string}")
+
+        left_time = self.settings.timeout
+        timeout = time.time() + self.settings.timeout
+        while (left_time > 0) and (number_executes != 0):
+            stats.append(self.execute_test(execute_line, left_time))
+            left_time = timeout - time.time()
+            number_executes -= 1
+        return stats
+
+    def update_capabilities(self, target_file: Path):
+        # use_sudo = False
+        suc_launch = False
+        used_max_perm = False
+
+        execute_line = ["setcap", "-q", "cap_sys_admin,cap_sys_nice=ep", str(target_file)]
+        while (not suc_launch) and (not used_max_perm):
+            # TODO: need think how to check that sudo on server is waiting for password or not.
+            # if use_sudo:
+            #     execute_line = ["sudo"] + execute_line
+            used_max_perm = True
+
+            chan = self.execute_command(" ".join(execute_line))
+            returncode = chan.recv_exit_status()
+            if returncode == 0:
+                suc_launch = True
+            else:
+                if used_max_perm:
+                    proc_err = chan.makefile_stderr().read().decode()
+                    print(f"[-]: Error during seting capability:\n {self.tab_lines(proc_err)}", file=sys.stderr)
+                # use_sudo = True
+
+    def send_file(self, loc_path: Path, host_path: Path):
+        self.sftp.put(str(loc_path), str(host_path))
+        self.sftp.chmod(str(host_path), stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH)
+
+    def collect(self, build_channel: Queue[CSignal.End | CSignal.BuiltFile]) -> Dict[str, Dict]:
+        analyzed: Dict[str, List[TestRes]] = {}
+
+        while True:
+            sign = build_channel.get()
+            match sign:
+                case CSignal.End():
+                    break
+                case CSignal.BuiltFile(binary):
+                    host_binary = self.bin_dir.joinpath(binary.name)
+                    self.send_file(binary, host_binary)
+                    self.update_capabilities(host_binary)
+                    data = self.get_stat(host_binary, self.max_test_launches)
+                    analyzed[host_binary.name.split(".")[0]] = data
+                case _:
+                    raise Exception(f"Get unexpected channel signal {sign}")
+
+        return PerfParser.correct(analyzed)

--- a/src/analyzers/patchers/attachments/perfTemplate.c
+++ b/src/analyzers/patchers/attachments/perfTemplate.c
@@ -11,6 +11,8 @@
 
 void test_fun();
 
+#define EXIT_SIGNAL 2
+
 int* perf_fd;
 size_t perf_fd_len = 0;
 unsigned long long configs[] = {PERF_COUNT_HW_BRANCH_INSTRUCTIONS, PERF_COUNT_HW_BRANCH_MISSES, PERF_COUNT_HW_CACHE_BPU,
@@ -84,7 +86,7 @@ static void fin() {
     }
 }
 
-static void sigint_handler() { exit(0); }
+static void sigint_handler() { exit(EXIT_SIGNAL); }
 
 int main(int argc, char* argv[]) {
     atexit(fin);

--- a/src/analyzers/sshAnalyzer.py
+++ b/src/analyzers/sshAnalyzer.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from argparse import Namespace
+import logging
+from pathlib import Path
+from typing import Dict
+
+from src.analyzers.backGroundBuildAnalyzer import BGBuildAnalyzer
+from src.analyzers.collectors.sshCollector import SshCollector
+from src.helpers.backGroundBuilder import BGBuilder
+from src.analyzers.patchers.perfPatcher import PerfPatcher
+from src.protocols.analyzer import Analyzer
+
+
+class SshAnalyzer:
+    def __init__(self, builder: BGBuilder, settings: Namespace):
+        self.settings = settings
+        self.builder: BGBuilder = builder
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(self.settings.log_level)
+
+        self.base: Analyzer = BGBuildAnalyzer(PerfPatcher(settings), self.builder, SshCollector(settings), settings)
+
+    def analyze(self, test_dir: Path) -> Dict[str, Dict]:
+        return self.base.analyze(test_dir)

--- a/src/cli/analyze.py
+++ b/src/cli/analyze.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from pprint import pformat
 from typing import Dict, List
 
+from src.analyzers.sshAnalyzer import SshAnalyzer
+from src.helpers.backGroundBuilder import BGBuilder
 from src.analyzers.gemAnalyzer import GemAnalyzer
 from src.analyzers.perfAnalyzer import PerfAnalyzer
 from src.helpers.builder import Builder
@@ -32,12 +34,15 @@ class Analyze:
         self.analyze_dir = Path(settings.out_dir)
         self.settings.compiler_args = shlex.split(settings.compiler_args)
         self.builder = Builder(self.settings)
-        if settings.profiler == "perf":
-            self.analyzer = PerfAnalyzer(self.builder, settings)
-        elif settings.profiler == "gem5":
-            self.analyzer = GemAnalyzer(self.builder, settings)
-        else:
-            raise Exception(f'"{settings.profiler}" is unknown profiler')
+        match settings.profiler:
+            case "perf":
+                self.analyzer = PerfAnalyzer(self.builder, settings)
+            case "gem5":
+                self.analyzer = GemAnalyzer(self.builder, settings)
+            case "ssh":
+                self.analyzer = SshAnalyzer(BGBuilder(settings, self.builder), settings)
+            case _:
+                raise Exception(f'"{settings.profiler}" is unknown profiler')
 
     def run(self) -> None:
         self.logger.info("Analyze running. Settings:")

--- a/src/helpers/backGroundBuilder.py
+++ b/src/helpers/backGroundBuilder.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+import logging
+import os
+from argparse import Namespace
+from pathlib import Path
+from queue import Queue
+import threading
+from typing import TypeAlias
+
+from src.helpers.builder import Builder
+
+
+class CSignal:
+    class End:
+        pass
+
+    @dataclass
+    class BuiltFile:
+        f: Path
+
+
+ChanSignal: TypeAlias = CSignal.BuiltFile | CSignal.End
+
+
+class BGBuilder:
+    # TODO: rewrite it more thread safety
+
+    def __init__(self, settings: Namespace, builder: Builder | None = None):
+        self.settings = settings
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(self.settings.log_level)
+
+        if builder is None:
+            builder = Builder(settings)
+        self.builder = builder
+
+    def build(
+        self,
+        src_file: Path,
+        destination_file: Path,
+        additional_flags: list[str] | None = None,
+    ):
+        self.builder.build(src_file, destination_file, additional_flags)
+
+    def _build_dir(
+        self,
+        src_dir: Path,
+        destination_dir: Path,
+        out_channel: Queue[ChanSignal],
+        additional_flags: list[str] | None = None,
+    ):
+        list_of_src_files = os.listdir(src_dir)
+        destination_dir.mkdir(parents=True, exist_ok=True)
+
+        for test_file in list_of_src_files:
+            out_file = destination_dir.joinpath(f"{test_file}.out")
+            self.build(src_dir.joinpath(test_file), out_file, additional_flags)
+            out_channel.put(CSignal.BuiltFile(out_file))
+
+        out_channel.put(CSignal.End())
+
+    def build_dir(
+        self,
+        src_dir: Path,
+        destination_dir: Path,
+        additional_flags: list[str] | None = None,
+    ) -> Queue[ChanSignal]:
+        out_channel: Queue[ChanSignal] = Queue()
+        threading.Thread(
+            target=self._build_dir,
+            args=(src_dir, destination_dir, out_channel, additional_flags),
+        ).start()
+        return out_channel

--- a/src/helpers/backGroundBuilder.py
+++ b/src/helpers/backGroundBuilder.py
@@ -23,23 +23,17 @@ ChanSignal: TypeAlias = CSignal.BuiltFile | CSignal.End
 
 
 class BGBuilder:
-    # TODO: rewrite it more thread safety
-
     def __init__(self, settings: Namespace, builder: Builder | None = None):
         self.settings = settings
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(self.settings.log_level)
 
+        self.builder_mutex = threading.Lock()
         if builder is None:
             builder = Builder(settings)
         self.builder = builder
 
-    def build(
-        self,
-        src_file: Path,
-        destination_file: Path,
-        additional_flags: list[str] | None = None,
-    ):
+    def _build(self, src_file: Path, destination_file: Path, additional_flags: list[str] | None = None):
         self.builder.build(src_file, destination_file, additional_flags)
 
     def _build_dir(
@@ -52,12 +46,19 @@ class BGBuilder:
         list_of_src_files = os.listdir(src_dir)
         destination_dir.mkdir(parents=True, exist_ok=True)
 
+        self.builder_mutex.acquire()
         for test_file in list_of_src_files:
             out_file = destination_dir.joinpath(f"{test_file}.out")
-            self.build(src_dir.joinpath(test_file), out_file, additional_flags)
+            self._build(src_dir.joinpath(test_file), out_file, additional_flags)
             out_channel.put(CSignal.BuiltFile(out_file))
+        self.builder_mutex.release()
 
         out_channel.put(CSignal.End())
+
+    def build(self, src_file: Path, destination_file: Path, additional_flags: list[str] | None = None):
+        self.builder_mutex.acquire()
+        self._build(src_file, destination_file, additional_flags)
+        self.builder_mutex.release()
 
     def build_dir(
         self,

--- a/src/helpers/builder.py
+++ b/src/helpers/builder.py
@@ -17,22 +17,32 @@ class Builder:
 
     def build(
         self,
-        src_dir: Path,
-        destination_dir: Path,
+        src_file: Path,
+        destination_file: Path,
         additional_flags: list[str] | None = None,
     ) -> None:
         if additional_flags is None:
             additional_flags = self.default_additional_flags
 
+        destination_file.parent.mkdir(parents=True, exist_ok=True)
+        execute_line = (
+            [self.settings.compiler, src_file]
+            + self.settings.compiler_args
+            + ["-o", destination_file]
+            + additional_flags
+        )
+        self.logger.info(f"Builder(Analyze) is running. Executed command:{execute_line}")
+
+        subprocess.run(execute_line, check=True)
+
+    def build_dir(
+        self,
+        src_dir: Path,
+        destination_dir: Path,
+        additional_flags: list[str] | None = None,
+    ):
         list_of_src_files = os.listdir(src_dir)
         destination_dir.mkdir(parents=True, exist_ok=True)
-        for test_file in list_of_src_files:
-            execute_line = (
-                [self.settings.compiler, src_dir.joinpath(test_file)]
-                + self.settings.compiler_args
-                + ["-o", destination_dir.joinpath(f"{test_file}.out")]
-                + additional_flags
-            )
-            self.logger.info(f"Builder(Analyze) is running. Executed command:{execute_line}")
 
-            subprocess.run(execute_line, check=True)
+        for test_file in list_of_src_files:
+            self.build(src_dir.joinpath(test_file), destination_dir.joinpath(f"{test_file}.out"), additional_flags)

--- a/src/protocols/queueCollector.py
+++ b/src/protocols/queueCollector.py
@@ -1,0 +1,9 @@
+from queue import Queue
+from typing import Dict, Protocol
+
+from src.helpers.backGroundBuilder import ChanSignal
+
+
+class QueueCollector(Protocol):
+    def collect(self, build_channel: Queue[ChanSignal]) -> Dict[str, Dict]:
+        ...


### PR DESCRIPTION
Add BackGroundBuilder and analyzer for it:
- now it is able to build binaries and launch it for testing simultaneously
- latter planned to add a background patcher to them

Add ssh analyzer (fix: #53):
- can connect by password or key
- send binaries (tests), launch them and collect data
- need root user at test machine for correct work 