### PR TITLE
Fix aggregate with multiple configs error, and incorrect default params

### DIFF
--- a/docs/usage/Analyze.md
+++ b/docs/usage/Analyze.md
@@ -33,7 +33,7 @@ python3 cha.py analyze --config-file "path/to/config_file"
 ```
 
 ### Output directory
-Specify a custom directory to save the analysis results. By default, results will be saved in the `analyze` directory. Specified directory will contain analysis results in the form of `.data` file.\
+Specify a custom directory to save the analysis results. By default, results will be saved in the `chapy-analyze` directory. Specified directory will contain analysis results in the form of `.data` file.\
 **Note**: If the specified directory does not exist, it will be created. And, if the directory is not empty, the existing files will be removed, and overwritten with the new analysis results.
 #### Usage example:
 ```shell
@@ -42,7 +42,7 @@ python3 cha.py analyze --out-dir "outputDir"
 ```
 
 ### Tests directory
-Specify the path to the directory containing the tests. By default, tests are expected in the `tests` directory. Directory should contain one or more test files written in `C language`.
+Specify the path to the directory containing the tests. By default, tests are expected in the `chapy-tests` directory. Directory should contain one or more test files written in `C language`.
 #### Usage example:
 ```shell
 # Use tests from "testsDir" directory
@@ -79,14 +79,14 @@ python3 cha.py analyze --profiler otherProfiler
 ```
 
 ### Path to gem5 Home
-Specify the path to the gem5 home directory. By default, the gem5 home directory is not specified.
+Specify the path to the gem5 home directory. By default, the gem5 home directory is `./thirdparty/gem5/`.
 #### Usage example:
 ```shell
 # Set gem5 home directory
 python3 cha.py analyze --gem5-home "path/to/gem5_home"
 ```
 ### Path to gem5 Binary
-Specify the path to the gem5 binary. By default, the gem5 binary path is not specified.
+Specify the path to the gem5 binary. By default, the gem5 binary path is `./`.
 #### Usage example:
 ```shell
 # Set gem5 binary path

--- a/src/cli/aggregate.py
+++ b/src/cli/aggregate.py
@@ -10,13 +10,15 @@ from typing import Final, List, Dict, Any
 
 from src.cli.analyze import Analyze
 from src.protocols.utility import Utility
+from src.helpers.configurator import LogLevel
 
 
 DEFAULT_GENERATE_SETTINGS: Final[dict] = {
     "utility": "generate",
     "out_dir": "chapy-tests",
     "repeats": 1,
-    "log_level": "WARNING",
+    "seed": None,
+    "log_level": LogLevel.WARNING,
 }
 
 DEFAULT_ANALYZE_SETTINGS: Final[dict] = {
@@ -32,7 +34,7 @@ DEFAULT_ANALYZE_SETTINGS: Final[dict] = {
     "gem5_bin": "./",
     "target_isa": "",
     "sim_script": "./",
-    "log_level": "WARNING",
+    "log_level": LogLevel.WARNING,
 }
 
 DEFAULT_SUMMARIZE_SETTINGS: Final[dict] = {
@@ -41,7 +43,16 @@ DEFAULT_SUMMARIZE_SETTINGS: Final[dict] = {
     "out_dir": "summarize",
     "no_show_graph": False,
     "no_save_graph": False,
-    "log_level": "WARNING",
+    "log_level": LogLevel.WARNING,
+}
+
+DEFAULT_AGGREGATE_SETTINGS: Final[dict] = {
+    "utility": "aggregate",
+    "config_file": "config.json",
+    "section_in_config": "DEFAULT",
+    "dest_dir": "out",
+    "async_analyze": False,
+    "log_level": LogLevel.WARNING,
 }
 
 

--- a/src/cli/aggregate.py
+++ b/src/cli/aggregate.py
@@ -90,7 +90,7 @@ class Aggregate(Utility):
 
         return output_analyze_dirs
 
-    def create_analyzer(self, config_file: Path) -> Analyze:
+    def create_analyzer(self, config_file: Path, settings_analyze: Dict[str, Any]) -> Analyze:
         """Create and configure an Analyze instance based on the provided configuration file
 
         :param config_file: The path to the configuration file.
@@ -100,22 +100,22 @@ class Aggregate(Utility):
         full_conf_path = Path(self.settings["path_to_configs"]).joinpath(config_file)
         if os.access(full_conf_path, mode=os.R_OK):
             cfg_settings = self.settings["configurator"].read_cfg_file(full_conf_path)
-            self.default_analyze_settings = self.settings["configurator"].get_true_settings(
+            settings_analyze = self.settings["configurator"].get_true_settings(
                 cfg_settings,
-                self.default_analyze_settings,
+                settings_analyze,
             )
             # if user set absolute path in config, we will save by it
-            if not Path(self.default_analyze_settings["out_dir"]).is_absolute():
+            if not Path(settings_analyze["out_dir"]).is_absolute():
                 name = full_conf_path.name.split(".")[0]
                 sub_dir_name = f"{name}-{datetime.now().strftime('%y-%m-%d-%H-%M-%S-%f')}"
                 sub_dir = Path(self.settings["dest_dir"]).joinpath(sub_dir_name)
                 while sub_dir.exists():
                     sub_dir_name = sub_dir_name + "_new"
                     sub_dir = sub_dir.with_name(sub_dir_name)
-                self.default_analyze_settings["out_dir"] = sub_dir.joinpath(self.default_analyze_settings["out_dir"])
+                settings_analyze["out_dir"] = sub_dir.joinpath(settings_analyze["out_dir"])
 
-            self.default_analyze_settings["log_level"] = self.settings["log_level"]
-            analyze.configurate(self.default_analyze_settings)
+            settings_analyze["log_level"] = self.settings["log_level"]
+            analyze.configurate(settings_analyze)
 
         return analyze
 
@@ -155,4 +155,4 @@ class Aggregate(Utility):
         """
         self.settings = {**self.settings, **settings}
         self.logger.setLevel(self.settings["log_level"])
-        self.analyzes = [self.create_analyzer(cfg) for cfg in self.settings["configs"]]
+        self.analyzes = [self.create_analyzer(cfg, self.default_analyze_settings) for cfg in self.settings["configs"]]

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -19,17 +19,24 @@ class ProfilerType(str, Enum):
 class Configurator:
     """Class for handling configuration files and argument parsing"""
 
-    def configurate(self, args: Dict[str, Any]):
-        """Update the provided arguments with configuration file contents if specified
+    def configurate(self, args: Dict[str, Any], default_args: Dict[str, Any]):
+        """Update the provided arguments with configuration file contents if specified.
+        Arguments priority: default_args < config_args < provided_args
 
         :param args: Dictionary of arguments
+        :param default_args: Dictionary of default arguments
         """
         config_file = args.get("config_file")
         section_in_config = args.get("section_in_config")
 
         if config_file:
             config = self.read_cfg_file(config_file, section_in_config)
-            args.update(config)
+            for key, value in config.items():
+                if key in args:
+                    if args[key] == default_args[key]:
+                        args[key] = value
+                else:
+                    args[key] = value
 
     def read_cfg_file(self, config_file: str | None, section: str | None = None) -> Dict[str, Any]:
         """Read a configuration file and return its contents

--- a/src/helpers/configurator.py
+++ b/src/helpers/configurator.py
@@ -53,9 +53,6 @@ class Configurator:
         """
         result: Dict[str, Any] = settings
         for arg in args:
-            if arg in settings:
-                if args[arg] != settings[arg]:
-                    settings[arg] = args[arg]
-            else:
+            if arg not in settings:
                 settings[arg] = args[arg]
         return result

--- a/src/helpers/controller.py
+++ b/src/helpers/controller.py
@@ -3,7 +3,13 @@ from typing import Dict, List, Optional
 import typer
 from typing_extensions import Annotated
 
-from src.cli.aggregate import Aggregate, DEFAULT_GENERATE_SETTINGS
+from src.cli.aggregate import (
+    Aggregate,
+    DEFAULT_GENERATE_SETTINGS,
+    DEFAULT_ANALYZE_SETTINGS,
+    DEFAULT_SUMMARIZE_SETTINGS,
+    DEFAULT_AGGREGATE_SETTINGS,
+)
 from src.cli.analyze import Analyze
 from src.cli.generate import Generate
 from src.cli.summarize import Summarize
@@ -22,13 +28,15 @@ def init_generator(
     ] = DEFAULT_GENERATE_SETTINGS["out_dir"],
     repeats: Annotated[
         int, typer.Option(help="Count of repeats to generated test", metavar="REPEATS", show_default=False)
-    ] = 1,
+    ] = DEFAULT_GENERATE_SETTINGS["repeats"],
     seed: Annotated[
         int, typer.Option(help="Integer to use as seed to random test generation", metavar="SEED", show_default=False)
-    ] = None,
-    log_level: Annotated[LogLevel, typer.Option(help="Log level of program", case_sensitive=True)] = LogLevel.WARNING,
+    ] = DEFAULT_GENERATE_SETTINGS["seed"],
+    log_level: Annotated[
+        LogLevel, typer.Option(help="Log level of program", case_sensitive=True)
+    ] = DEFAULT_GENERATE_SETTINGS["log_level"],
 ):
-    command_args["utility"] = "generate"
+    command_args["utility"] = DEFAULT_GENERATE_SETTINGS["utility"]
     command_args["out_dir"] = out_dir
     command_args["repeats"] = repeats
     command_args["seed"] = seed
@@ -40,42 +48,48 @@ def init_generator(
 def init_analyzer(
     config_file: Annotated[
         Optional[str], typer.Option(help="Path to configuration file", metavar="CONFIG_FILE", show_default=False)
-    ] = None,
+    ] = DEFAULT_ANALYZE_SETTINGS["config_file"],
     out_dir: Annotated[
         str, typer.Option(help="Path to output directory", metavar="OUT_DIR", show_default=False)
-    ] = "analyze",
+    ] = DEFAULT_ANALYZE_SETTINGS["out_dir"],
     test_dir: Annotated[
         str, typer.Option(help="Path to directory with tests", metavar="TEST_DIR", show_default=False)
-    ] = DEFAULT_GENERATE_SETTINGS["out_dir"],
+    ] = DEFAULT_ANALYZE_SETTINGS["test_dir"],
     timeout: Annotated[
         int,
         typer.Option(
             help="Number of seconds after which the test will be stopped", metavar="TIMEOUT", show_default=False
         ),
-    ] = 10,
-    compiler: Annotated[str, typer.Option(help="Path to compiler", metavar="COMPILER", show_default=False)] = "gcc",
+    ] = DEFAULT_ANALYZE_SETTINGS["timeout"],
+    compiler: Annotated[
+        str, typer.Option(help="Path to compiler", metavar="COMPILER", show_default=False)
+    ] = DEFAULT_ANALYZE_SETTINGS["compiler"],
     compiler_args: Annotated[
         str, typer.Option(help="Pass arguments on to the compiler", metavar="COMPILER_ARGS", show_default=False)
-    ] = "",
-    profiler: Annotated[ProfilerType, typer.Option(help="Type of profiler")] = ProfilerType.PERF,
-    gem5_home: Annotated[str, typer.Option(help="Path to home gem5", metavar="GEM5_HOME", show_default=False)] = "./",
-    gem5_bin: Annotated[str, typer.Option(help="Path to execute gem5", metavar="GEM5_BIN", show_default=False)] = "./",
+    ] = DEFAULT_ANALYZE_SETTINGS["compiler_args"],
+    profiler: Annotated[ProfilerType, typer.Option(help="Type of profiler")] = DEFAULT_ANALYZE_SETTINGS["profiler"],
+    gem5_home: Annotated[
+        str, typer.Option(help="Path to home gem5", metavar="GEM5_HOME", show_default=False)
+    ] = DEFAULT_ANALYZE_SETTINGS["gem5_home"],
+    gem5_bin: Annotated[
+        str, typer.Option(help="Path to execute gem5", metavar="GEM5_BIN", show_default=False)
+    ] = DEFAULT_ANALYZE_SETTINGS["gem5_bin"],
     target_isa: Annotated[
         str, typer.Option(help="Type of architecture being simulated", metavar="TARGET_ISA", show_default=False)
-    ] = "",
+    ] = DEFAULT_ANALYZE_SETTINGS["target_isa"],
     sim_script: Annotated[
         str, typer.Option(help="Path to simulation Script", metavar="SIM_SCRIPT", show_default=False)
-    ] = "./",
-    log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = LogLevel.WARNING,
+    ] = DEFAULT_ANALYZE_SETTINGS["sim_script"],
+    log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = DEFAULT_ANALYZE_SETTINGS["log_level"],
 ):
-    command_args["utility"] = "analyze"
+    command_args["utility"] = DEFAULT_ANALYZE_SETTINGS["utility"]
     command_args["config_file"] = config_file
     command_args["out_dir"] = out_dir
     command_args["test_dir"] = test_dir
     command_args["timeout"] = timeout
     command_args["compiler"] = compiler
     command_args["compiler_args"] = compiler_args
-    command_args["profiler"] = profiler
+    command_args["profiler"] = profiler.value
     command_args["gem5_home"] = gem5_home
     command_args["gem5_bin"] = gem5_bin
     command_args["target_isa"] = target_isa
@@ -95,17 +109,17 @@ def init_summarizer(
     ] = None,
     out_dir: Annotated[
         str, typer.Option(help="Path to output directory", metavar="OUT_DIR", show_default=False)
-    ] = "summarize",
+    ] = DEFAULT_SUMMARIZE_SETTINGS["out_dir"],
     no_show_graph: Annotated[
         bool, typer.Option("--no-show-graph", help="Shows a graph of BP incorrect %%", show_default=False)
-    ] = False,
+    ] = DEFAULT_SUMMARIZE_SETTINGS["no_show_graph"],
     no_save_graph: Annotated[
         bool,
-        typer.Option("--no-save-graph", help="Saves a graph of BP incorrect %% " "in graph.png", show_default=False),
-    ] = False,
-    log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = LogLevel.WARNING,
+        typer.Option("--no-save-graph", help="Saves a graph of BP incorrect %% in graph.png", show_default=False),
+    ] = DEFAULT_SUMMARIZE_SETTINGS["no_save_graph"],
+    log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = DEFAULT_SUMMARIZE_SETTINGS["log_level"],
 ):
-    command_args["utility"] = "summarize"
+    command_args["utility"] = DEFAULT_SUMMARIZE_SETTINGS["utility"]
     command_args["src_dirs"] = src_dirs
     command_args["out_dir"] = out_dir
     command_args["no_show_graph"] = no_show_graph
@@ -118,7 +132,7 @@ def init_summarizer(
 def init_aggregator(
     config_file: Annotated[
         str, typer.Option(help="Path to .cfg file", metavar="CONFIG_FILE", show_default=False)
-    ] = "config.json",
+    ] = DEFAULT_AGGREGATE_SETTINGS["config_file"],
     section_in_config: Annotated[
         str,
         typer.Option(
@@ -126,11 +140,11 @@ def init_aggregator(
             metavar="SECTION_IN_CONFIG",
             show_default=False,
         ),
-    ] = "DEFAULT",
+    ] = DEFAULT_AGGREGATE_SETTINGS["section_in_config"],
     dest_dir: Annotated[
         str,
         typer.Option(help="Path to dist dir, if not exit it will be created", metavar="OUT_DIR", show_default=False),
-    ] = "out",
+    ] = DEFAULT_AGGREGATE_SETTINGS["dest_dir"],
     async_analyze: Annotated[
         bool,
         typer.Option(
@@ -139,10 +153,10 @@ def init_aggregator(
             metavar="ASYNC_ANALYZE",
             show_default=False,
         ),
-    ] = False,
-    log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = LogLevel.WARNING,
+    ] = DEFAULT_AGGREGATE_SETTINGS["async_analyze"],
+    log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = DEFAULT_AGGREGATE_SETTINGS["log_level"],
 ):
-    command_args["utility"] = "aggregate"
+    command_args["utility"] = DEFAULT_AGGREGATE_SETTINGS["utility"]
     command_args["config_file"] = config_file
     command_args["section_in_config"] = section_in_config
     command_args["dest_dir"] = dest_dir

--- a/src/helpers/controller.py
+++ b/src/helpers/controller.py
@@ -95,7 +95,7 @@ def init_analyzer(
     command_args["target_isa"] = target_isa
     command_args["sim_script"] = sim_script
     command_args["log_level"] = log_level.value
-    configurator.configurate(command_args)
+    configurator.configurate(command_args, DEFAULT_ANALYZE_SETTINGS)
     run_utility()
 
 
@@ -162,7 +162,7 @@ def init_aggregator(
     command_args["dest_dir"] = dest_dir
     command_args["async_analyze"] = async_analyze
     command_args["log_level"] = log_level.value
-    configurator.configurate(command_args)
+    configurator.configurate(command_args, DEFAULT_AGGREGATE_SETTINGS)
     run_utility()
 
 

--- a/src/helpers/controller.py
+++ b/src/helpers/controller.py
@@ -139,7 +139,7 @@ def init_aggregator(
             metavar="ASYNC_ANALYZE",
             show_default=False,
         ),
-    ] = True,
+    ] = False,
     log_level: Annotated[LogLevel, typer.Option(help="Log level of program")] = LogLevel.WARNING,
 ):
     command_args["utility"] = "aggregate"

--- a/tests/cli/test_typer_commands.py
+++ b/tests/cli/test_typer_commands.py
@@ -86,6 +86,7 @@ def test_run_generate_with_default_options():
     assert command_args["utility"] == "generate"
     assert command_args["out_dir"] == "chapy-tests"
     assert command_args["repeats"] == 1
+    assert command_args["seed"] is None
     assert command_args["log_level"] == "WARNING"
 
 
@@ -114,13 +115,13 @@ def test_run_analyze_with_default_options():
     runner.invoke(app, ["analyze"])
     assert command_args["utility"] == "analyze"
     assert command_args["config_file"] is None
-    assert command_args["out_dir"] == "analyze"
+    assert command_args["out_dir"] == "chapy-analyze"
     assert command_args["test_dir"] == "chapy-tests"
     assert command_args["timeout"] == 10
     assert command_args["compiler"] == "gcc"
     assert command_args["compiler_args"] == ""
     assert command_args["profiler"] == "perf"
-    assert command_args["gem5_home"] == "./"
+    assert command_args["gem5_home"] == "./thirdparty/gem5/"
     assert command_args["gem5_bin"] == "./"
     assert command_args["target_isa"] == ""
     assert command_args["sim_script"] == "./"

--- a/tests/cli/test_typer_commands.py
+++ b/tests/cli/test_typer_commands.py
@@ -163,5 +163,5 @@ def test_run_aggregate_with_default_options():
     assert command_args["config_file"] == "config.json"
     assert command_args["section_in_config"] == "DEFAULT"
     assert command_args["dest_dir"] == "out"
-    assert command_args["async_analyze"] is True
+    assert command_args["async_analyze"] is False
     assert command_args["log_level"] == "WARNING"


### PR DESCRIPTION
- There was an error when launching aggregate and passing multiple configs through config-file. That error ocurred after switching to typer. Fixed it!
- Removed small if condition in configurator, because it was always `False`
- Resolved #97 
- Replaced hard-coded default command settings in controller.py with values from the settings dictionary in aggregate.py to ensure consistency and simplify future updates
- Updated typer_commands tests' ecpected default params according to new default settings
- Updated user documentation to match new default settings